### PR TITLE
Correct vscode settings to relative path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,5 @@
         "**/*.pytest_cache": true,
         "**/*.coverage": true
     },
-    "python.pythonPath": "/Users/gtalarico/dev/repos/gtalarico/aec.works/aec.works-api/.venv/bin/python3.8",
+    "python.pythonPath": ".venv/bin/python3.8",
 }


### PR DESCRIPTION
An alternative to #17 -> sets interpreter to local project venv created by setup script