### PR TITLE
Profile search

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -5,7 +5,7 @@ from .models import Profile
 class ProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = Profile
-        fields = ["slug", "name", "avatar_url"]
+        fields = ["slug", "name", "bio", "location", "avatar_url"]
 
 
 class ProfileDetailSerializer(serializers.ModelSerializer):

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -1,4 +1,4 @@
-from rest_framework import mixins, generics, views
+from rest_framework import mixins, generics, views, filters
 from rest_framework.response import Response
 from rest_framework import exceptions as drf_exceptions
 from rest_framework.pagination import LimitOffsetPagination
@@ -19,6 +19,9 @@ class ProfileListView(ErrorsMixin, mixins.ListModelMixin, generics.GenericAPIVie
     queryset = selectors.get_profiles()
     pagination_class = LimitOffsetPagination
     page_size = 100
+
+    search_fields = ["bio", "location", "user__name"]
+    filter_backends = [filters.SearchFilter]
 
     def get(self, request):
         return super().list(request)


### PR DESCRIPTION
* Adds `bio` and `location` to profile list serializer
* Adds `?search=` filter to `users/profiles/` endpoint to support search - search will do and OR search of `location`, `bio` and name.

These were added to support the redesigned people page by @daneyul :
https://www.notion.so/gtalarico/Redesign-People-List-Page-44721b15844a45338af416790c24982f