### PR TITLE
Use localhost instead of 0.0.0.0

### DIFF
--- a/scripts/serve-dev.sh
+++ b/scripts/serve-dev.sh
@@ -23,4 +23,4 @@ info ">>> Adding Dev User"
 python manage.py loaddata api/aecworks/fixtures/users.json
 
 info "Starting Django Dev Server..."
-exec python manage.py runserver 0.0.0.0:8000
+exec python manage.py runserver 8000


### PR DESCRIPTION
Previously was binding to 0.0.0.0 because dev server was inside a container.

The current setup uses virtual env so binding to 0* is not needed.

Turns out is **a lot slower**  - on my machine takes 5-10 seconds for dev server to warm up and respond first request.
While normally on localhost takes around 1 second.