### PR TITLE
Add cache

### DIFF
--- a/api/aecworks/settings.py
+++ b/api/aecworks/settings.py
@@ -182,6 +182,17 @@ CELERY_BROKER_URL = config("REDIS_URL")
 CELERY_RESULT_BACKEND = "django-db"
 CELERY_CACHE_BACKEND = "django-cache"
 
+# CACHE
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": f"{config('REDIS_URL')}/1",
+        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient",},
+    }
+}
+SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+SESSION_CACHE_ALIAS = "default"
+
 
 # Sentry
 if not DEBUG:

--- a/api/aecworks/settings.py
+++ b/api/aecworks/settings.py
@@ -187,7 +187,7 @@ CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": f"{config('REDIS_URL')}/1",
-        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient",},
+        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
     }
 }
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"

--- a/api/community/views/company.py
+++ b/api/community/views/company.py
@@ -136,7 +136,7 @@ class CompanyDetailView(
     lookup_field = "slug"
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
-    @method_decorator(cache_page(60 * 60))
+    @method_decorator(cache_page(60))
     def get(self, request, slug):
         return super().retrieve(request, slug)
 

--- a/api/community/views/company.py
+++ b/api/community/views/company.py
@@ -164,7 +164,7 @@ class CompanyListView(ErrorsMixin, mixins.ListModelMixin, generics.GenericAPIVie
             "name"
         )
 
-    @method_decorator(cache_page(60 * 60))
+    @method_decorator(cache_page(60))
     def get(self, request):
         """ Get Company List """
         return super().list(request)

--- a/api/community/views/company.py
+++ b/api/community/views/company.py
@@ -6,6 +6,8 @@ from rest_framework import (
     serializers,
     permissions,
 )
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 
 
 from api.permissions import IsEditorPermission, IsReadOnly
@@ -134,6 +136,7 @@ class CompanyDetailView(
     lookup_field = "slug"
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
+    @method_decorator(cache_page(60 * 60))
     def get(self, request, slug):
         return super().retrieve(request, slug)
 
@@ -161,6 +164,7 @@ class CompanyListView(ErrorsMixin, mixins.ListModelMixin, generics.GenericAPIVie
             "name"
         )
 
+    @method_decorator(cache_page(60 * 60))
     def get(self, request):
         """ Get Company List """
         return super().list(request)

--- a/api/community/views/posts.py
+++ b/api/community/views/posts.py
@@ -117,7 +117,7 @@ class PostDetailView(
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
     expected_exceptions = {PermissionDenied: drf_exceptions.PermissionDenied}
 
-    @method_decorator(cache_page(60 * 60))
+    @method_decorator(cache_page(60))
     def get(self, request, slug):
         return super().retrieve(request, slug)
 

--- a/api/community/views/posts.py
+++ b/api/community/views/posts.py
@@ -1,8 +1,10 @@
-from django.core.exceptions import PermissionDenied
 from rest_framework import mixins, generics, serializers, permissions
 from rest_framework import exceptions as drf_exceptions
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
+from django.core.exceptions import PermissionDenied
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 
 from api.common.exceptions import ErrorsMixin
 from api.users.serializers import ProfileSerializer
@@ -90,6 +92,7 @@ class PostListView(ErrorsMixin, mixins.ListModelMixin, generics.GenericAPIView):
             "-hot_datetime", "created_at", "slug"
         )
 
+    @method_decorator(cache_page(60 * 60))
     def get(self, request):
         return super().list(request)
 
@@ -115,6 +118,7 @@ class PostDetailView(
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
     expected_exceptions = {PermissionDenied: drf_exceptions.PermissionDenied}
 
+    @method_decorator(cache_page(60 * 60))
     def get(self, request, slug):
         return super().retrieve(request, slug)
 

--- a/api/community/views/posts.py
+++ b/api/community/views/posts.py
@@ -92,7 +92,6 @@ class PostListView(ErrorsMixin, mixins.ListModelMixin, generics.GenericAPIView):
             "-hot_datetime", "created_at", "slug"
         )
 
-    @method_decorator(cache_page(60 * 60))
     def get(self, request):
         return super().list(request)
 

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -4,6 +4,8 @@ from rest_framework import exceptions as drf_exceptions
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import IsAuthenticated
 
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from django.contrib.auth import login, logout, authenticate
 from api.common.exceptions import ErrorsMixin
 from . import selectors, services
@@ -23,6 +25,7 @@ class ProfileListView(ErrorsMixin, mixins.ListModelMixin, generics.GenericAPIVie
     search_fields = ["bio", "location", "user__name"]
     filter_backends = [filters.SearchFilter]
 
+    @method_decorator(cache_page(60 * 60))
     def get(self, request):
         return super().list(request)
 
@@ -34,6 +37,7 @@ class ProfileDetailView(
     queryset = Profile.objects.all()
     lookup_field = "slug"
 
+    @method_decorator(cache_page(60 * 60))
     def get(self, request, slug):
         return super().retrieve(request, slug)
 
@@ -43,6 +47,7 @@ class ProfileMeView(ErrorsMixin, mixins.RetrieveModelMixin, generics.GenericAPIV
     serializer_class = ProfileDetailSerializer
     queryset = Profile.objects.all()
 
+    @method_decorator(cache_page(60 * 60))
     def get(self, request):
         user = request.user
         serializer = self.get_serializer(user.profile)

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -25,7 +25,7 @@ class ProfileListView(ErrorsMixin, mixins.ListModelMixin, generics.GenericAPIVie
     search_fields = ["bio", "location", "user__name"]
     filter_backends = [filters.SearchFilter]
 
-    @method_decorator(cache_page(60 * 60))
+    @method_decorator(cache_page(60))
     def get(self, request):
         return super().list(request)
 
@@ -37,7 +37,7 @@ class ProfileDetailView(
     queryset = Profile.objects.all()
     lookup_field = "slug"
 
-    @method_decorator(cache_page(60 * 60))
+    @method_decorator(cache_page(60))
     def get(self, request, slug):
         return super().retrieve(request, slug)
 
@@ -47,7 +47,7 @@ class ProfileMeView(ErrorsMixin, mixins.RetrieveModelMixin, generics.GenericAPIV
     serializer_class = ProfileDetailSerializer
     queryset = Profile.objects.all()
 
-    @method_decorator(cache_page(60 * 60))
+    @method_decorator(cache_page(60))
     def get(self, request):
         user = request.user
         serializer = self.get_serializer(user.profile)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ django-jet==1.0.8
 django-mptt==0.11.0
 dj-database-url==0.5.0
 django-storages[boto3]==1.9.1
+django-redis==4.12.1
 
 django-querycount==0.7.0
 factory-boy==2.12.0


### PR DESCRIPTION
* Add redis backed cache to improve page load speed -  will probably need to adjust to break cache on certain calls

PS: right now worst offender is the company list endpoint, can take nearly 1000ms for a single page. - mostly caused by "Thread Count" value, which transverse the full comment tree to calculate comment total. That's not good. We should probably just save the count on thread object and increment as comments get added/removed.

Any insights on dealing with like/comment count?


### Testing
P95 - no cache: 652ms 👎
P95 - w/ cache: 167ms ✨