### PR TITLE
Adds `profile_has_clapped` to Company List View

### DIFF
--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -1,6 +1,8 @@
 import string
 import logging
 import requests
+from django.utils.html import format_html
+from django.urls import reverse
 from rest_framework import serializers
 from rest_framework.utils import model_meta
 from opengraph.opengraph import OpenGraph
@@ -68,3 +70,25 @@ def get_og_data(url: str):
         ]
         og_data = {k: v for k, v in og_article.items() if k in tags}
     return og_data
+
+
+def admin_linkify(field_name):
+    """
+    Converts a foreign key value into clickable links.
+
+    If field_name is 'parent', link text will be str(obj.parent)
+    Link will be admin url for the admin url for obj.parent.id:change
+    """
+
+    def _linkify(obj):
+        linked_obj = getattr(obj, field_name)
+        if linked_obj is None:
+            return "-"
+        app_label = linked_obj._meta.app_label
+        model_name = linked_obj._meta.model_name
+        view_name = f"admin:{app_label}_{model_name}_change"
+        link_url = reverse(view_name, args=[linked_obj.pk])
+        return format_html('<a href="{}">{}</a>', link_url, linked_obj)
+
+    _linkify.short_description = field_name  # Sets column name
+    return _linkify

--- a/api/community/admin.py
+++ b/api/community/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from api.common.utils import get_og_data
+from api.common.utils import get_og_data, admin_linkify
 from . import models
 
 
@@ -58,6 +58,7 @@ class CompanyAdmin(admin.ModelAdmin):
         "logo",
         "cover",
         "created_by",
+        admin_linkify(field_name="thread"),
     ]
     raw_id_fields = ["logo", "cover"]
     readonly_fields = ["thread"]

--- a/api/community/selectors.py
+++ b/api/community/selectors.py
@@ -22,6 +22,20 @@ def get_thread_comments(*, thread_id):
     return get_comments().filter(thread_id=thread_id)
 
 
+def get_thread_comments_annotated(*, thread_id, profile_id=-1):
+    return (
+        get_comments()
+        .filter(thread_id=thread_id)
+        .annotate(
+            user_did_clap=m.Case(
+                m.When(clappers__id__contains=profile_id, then=True),
+                default=False,
+                output_field=m.BooleanField(),
+            ),
+        )
+    )
+
+
 def get_company(**kwargs):
     return Company.objects.get(**kwargs)
 

--- a/api/community/services.py
+++ b/api/community/services.py
@@ -184,3 +184,7 @@ def parse_hashtag_query(query: str):
     if not query:
         return []
     return query.split(",")
+
+
+def get_clapped_companies(*, profile):
+    Company.clappers

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -47,7 +47,6 @@ class ProfileMeView(ErrorsMixin, mixins.RetrieveModelMixin, generics.GenericAPIV
     serializer_class = ProfileDetailSerializer
     queryset = Profile.objects.all()
 
-    @method_decorator(cache_page(60))
     def get(self, request):
         user = request.user
         serializer = self.get_serializer(user.profile)

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ django-redis==4.12.1
 django-querycount==0.7.0
 factory-boy==2.12.0
 django-extensions==2.2.9
-django-debug-toolbar==2.2
+django-debug-toolbar==2.2.1
 
 pytest==5.4.2
 pytest-django==3.9.0

--- a/tests/test_communities/test_selectors.py
+++ b/tests/test_communities/test_selectors.py
@@ -1,0 +1,45 @@
+import pytest
+from api.users.factories import ProfileFactory
+from api.community import factories, services, selectors
+
+
+@pytest.mark.django_db
+class TestSelectors:
+    def test_annotated_company(self):
+        profile_1 = ProfileFactory()
+        profile_2 = ProfileFactory()
+        company_1 = factories.CompanyFactory()
+        company_2 = factories.CompanyFactory()
+        assert company_1.clappers.count() == company_2.clappers.count() == 0
+        assert services.company_clap(company=company_1, profile=profile_1) == 1
+        assert services.company_clap(company=company_2, profile=profile_2) == 1
+
+        companies_1 = selectors.get_companies_annotated(profile_id=profile_1.id)
+        assert companies_1.all()[0].user_did_clap is True
+        assert companies_1.all()[1].user_did_clap is False
+        companies_2 = selectors.get_companies_annotated(profile_id=profile_2.id)
+        assert companies_2.all()[0].user_did_clap is False
+        assert companies_2.all()[1].user_did_clap is True
+
+    def test_annotated_comments(self):
+        thread = factories.ThreadFactory()
+
+        profile_1 = ProfileFactory()
+        profile_2 = ProfileFactory()
+        comment_1 = factories.CommentFactory(thread=thread)
+        comment_2 = factories.CommentFactory(thread=thread)
+        assert comment_1.clappers.count() == comment_2.clappers.count() == 0
+        assert services.comment_clap(comment=comment_1, profile=profile_1) == 1
+        assert services.comment_clap(comment=comment_2, profile=profile_2) == 1
+
+        comments_1 = selectors.get_thread_comments_annotated(
+            thread_id=thread.id, profile_id=profile_1.id
+        )
+        assert comments_1.all()[0].user_did_clap is True
+        assert comments_1.all()[1].user_did_clap is False
+
+        comments_2 = selectors.get_thread_comments_annotated(
+            thread_id=thread.id, profile_id=profile_2.id
+        )
+        assert comments_2.all()[0].user_did_clap is False
+        assert comments_2.all()[1].user_did_clap is True


### PR DESCRIPTION
Enables showing used/unused clap by providing bool value indicating if an authenticated user has clapped to the company.

Need some work on frontend to implement this consistently throughout website, and on comments
Might be nice to add a subtle animation on clap too, maybe scale up and fade....

### Implemented
* company and comment list now include `user_did_clap` - values returned True if user authenticated and has clapped, else false
* counting is done efficiently through ORM annotate feature
* Misc bug fix, removed profile cache
* thread link in admin
* update django toolbar

![claps](https://user-images.githubusercontent.com/9513968/114991559-8fac3f00-9e4e-11eb-89ca-af6558be549e.gif)
